### PR TITLE
Update AudioClip.cs

### DIFF
--- a/Unity Studio/Unity Classes/AudioClip.cs
+++ b/Unity Studio/Unity Classes/AudioClip.cs
@@ -115,6 +115,10 @@ namespace Unity_Studio
                     {
                         estream.Position = m_Offset;
                         m_AudioData = estream.ReadBytes((int)m_Size);
+                    }else
+                    {
+                        // can't find m_source file
+                        m_AudioData = a_Stream.ReadBytes((int)m_Size);
                     }
                 }
             }


### PR DESCRIPTION
fix bug: can't export AudioClip from obb file

修复从AudioClip从obb文件中解析失败的bug