### PR TITLE
Fix for mesh weights with nested armatures

### DIFF
--- a/AssetStudioUtility/ModelConverter.cs
+++ b/AssetStudioUtility/ModelConverter.cs
@@ -437,7 +437,7 @@ namespace AssetStudio
                     }
                     else
                     {
-                        //Logger.Error("");
+                        boneType = 2;
                     }
                 }
                 else


### PR DESCRIPTION
Hello, I've tried to export the `HuntressBody` object from the game `Risk of Rain 2`. Some of the meshes were exported without weights. I've looked at prefab and saw that it has one armature parented to the bone of another armature. Then I've debugged the exporting process line by line and found out that `sMesh.m_Bones` had 69 bones whereas `mesh.m_BindPose` had 68. And I think it was caused by armature inside armature. So I've made my change and exported again, and everything was exported as it should with all weights and everything. 