### PR TITLE
[GUI] Fix \0 chars in TextAssets cutting off preview

### DIFF
--- a/AssetStudioGUI/AssetStudioGUIForm.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.cs
@@ -926,7 +926,8 @@ namespace AssetStudioGUI
         private void PreviewTextAsset(TextAsset m_TextAsset)
         {
             var text = Encoding.UTF8.GetString(m_TextAsset.m_Script);
-            PreviewText(text.Replace("\n", "\r\n"));
+            text = text.Replace("\n", "\r\n").Replace("\0", "");
+            PreviewText(text);
         }
 
         private void PreviewMonoBehaviour(MonoBehaviour m_MonoBehaviour)


### PR DESCRIPTION
Fixes TextAsset preview getting cut off early if the text contains \0 characters. (WinForms textboxes cut text after the first \0.)