### PR TITLE
Adds exporter for list of assets to XML

### DIFF
--- a/AssetStudioGUI/AssetStudioGUIForm.Designer.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.Designer.cs
@@ -64,6 +64,11 @@
             this.toolStripMenuItem7 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem8 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem9 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripMenuItem10 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem11 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem12 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem13 = new System.Windows.Forms.ToolStripMenuItem();
             this.filterTypeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.allToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.debugMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -314,7 +319,9 @@
             this.exportAnimatorWithSelectedAnimationClipToolStripMenuItem,
             this.toolStripSeparator4,
             this.toolStripMenuItem2,
-            this.toolStripMenuItem3});
+            this.toolStripMenuItem3,
+            this.toolStripSeparator2,
+            this.toolStripMenuItem10});
             this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
             this.exportToolStripMenuItem.Size = new System.Drawing.Size(58, 21);
             this.exportToolStripMenuItem.Text = "Export";
@@ -418,6 +425,42 @@
             this.toolStripMenuItem9.Size = new System.Drawing.Size(165, 22);
             this.toolStripMenuItem9.Text = "Filtered assets";
             this.toolStripMenuItem9.Click += new System.EventHandler(this.toolStripMenuItem9_Click);
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(396, 6);
+            // 
+            // toolStripMenuItem10
+            // 
+            this.toolStripMenuItem10.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItem11,
+            this.toolStripMenuItem12,
+            this.toolStripMenuItem13});
+            this.toolStripMenuItem10.Name = "toolStripMenuItem10";
+            this.toolStripMenuItem10.Size = new System.Drawing.Size(399, 34);
+            this.toolStripMenuItem10.Text = "Asset list to XML";
+            // 
+            // toolStripMenuItem11
+            // 
+            this.toolStripMenuItem11.Name = "toolStripMenuItem11";
+            this.toolStripMenuItem11.Size = new System.Drawing.Size(270, 34);
+            this.toolStripMenuItem11.Text = "All assets";
+            this.toolStripMenuItem11.Click += new System.EventHandler(this.toolStripMenuItem11_Click);
+            // 
+            // toolStripMenuItem12
+            // 
+            this.toolStripMenuItem12.Name = "toolStripMenuItem12";
+            this.toolStripMenuItem12.Size = new System.Drawing.Size(270, 34);
+            this.toolStripMenuItem12.Text = "Selected assets";
+            this.toolStripMenuItem12.Click += new System.EventHandler(this.toolStripMenuItem12_Click);
+            // 
+            // toolStripMenuItem13
+            // 
+            this.toolStripMenuItem13.Name = "toolStripMenuItem13";
+            this.toolStripMenuItem13.Size = new System.Drawing.Size(270, 34);
+            this.toolStripMenuItem13.Text = "Filtered assets";
+            this.toolStripMenuItem13.Click += new System.EventHandler(this.toolStripMenuItem13_Click);
             // 
             // filterTypeToolStripMenuItem
             // 
@@ -1130,6 +1173,11 @@
         private System.Windows.Forms.TabPage tabPage4;
         private System.Windows.Forms.TabPage tabPage5;
         private System.Windows.Forms.TextBox dumpTextBox;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem10;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem11;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem12;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem13;
     }
 }
 

--- a/AssetStudioGUI/AssetStudioGUIForm.cs
+++ b/AssetStudioGUI/AssetStudioGUIForm.cs
@@ -1273,7 +1273,7 @@ namespace AssetStudioGUI
 
         private void exportSelectedAssetsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            ExportAssets(2, ExportType.Convert);
+            ExportAssets(ExportFilter.Selected, ExportType.Convert);
         }
 
         private void showOriginalFileToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1397,47 +1397,62 @@ namespace AssetStudioGUI
 
         private void exportAllAssetsMenuItem_Click(object sender, EventArgs e)
         {
-            ExportAssets(1, ExportType.Convert);
+            ExportAssets(ExportFilter.All, ExportType.Convert);
         }
 
         private void exportSelectedAssetsMenuItem_Click(object sender, EventArgs e)
         {
-            ExportAssets(2, ExportType.Convert);
+            ExportAssets(ExportFilter.Selected, ExportType.Convert);
         }
 
         private void exportFilteredAssetsMenuItem_Click(object sender, EventArgs e)
         {
-            ExportAssets(3, ExportType.Convert);
+            ExportAssets(ExportFilter.Filtered, ExportType.Convert);
         }
 
         private void toolStripMenuItem4_Click(object sender, EventArgs e)
         {
-            ExportAssets(1, ExportType.Raw);
+            ExportAssets(ExportFilter.All, ExportType.Raw);
         }
 
         private void toolStripMenuItem5_Click(object sender, EventArgs e)
         {
-            ExportAssets(2, ExportType.Raw);
+            ExportAssets(ExportFilter.Selected, ExportType.Raw);
         }
 
         private void toolStripMenuItem6_Click(object sender, EventArgs e)
         {
-            ExportAssets(3, ExportType.Raw);
+            ExportAssets(ExportFilter.Filtered, ExportType.Raw);
         }
 
         private void toolStripMenuItem7_Click(object sender, EventArgs e)
         {
-            ExportAssets(1, ExportType.Dump);
+            ExportAssets(ExportFilter.All, ExportType.Dump);
         }
 
         private void toolStripMenuItem8_Click(object sender, EventArgs e)
         {
-            ExportAssets(2, ExportType.Dump);
+            ExportAssets(ExportFilter.Selected, ExportType.Dump);
         }
 
         private void toolStripMenuItem9_Click(object sender, EventArgs e)
         {
-            ExportAssets(3, ExportType.Dump);
+            ExportAssets(ExportFilter.Filtered, ExportType.Dump);
+        }
+
+        private void toolStripMenuItem11_Click(object sender, EventArgs e)
+        {
+            ExportAssetsList(ExportFilter.All);
+        }
+
+        private void toolStripMenuItem12_Click(object sender, EventArgs e)
+        {
+            ExportAssetsList(ExportFilter.Selected);
+        }
+
+        private void toolStripMenuItem13_Click(object sender, EventArgs e)
+        {
+            ExportAssetsList(ExportFilter.Filtered);
         }
 
         private void exportAllObjectssplitToolStripMenuItem1_Click(object sender, EventArgs e)
@@ -1500,7 +1515,7 @@ namespace AssetStudioGUI
             assetListView.EndUpdate();
         }
 
-        private void ExportAssets(int type, ExportType exportType)
+        private void ExportAssets(ExportFilter type, ExportType exportType)
         {
             if (exportableAssets.Count > 0)
             {
@@ -1512,17 +1527,50 @@ namespace AssetStudioGUI
                     List<AssetItem> toExportAssets = null;
                     switch (type)
                     {
-                        case 1: //All Assets
+                        case ExportFilter.All:
                             toExportAssets = exportableAssets;
                             break;
-                        case 2: //Selected Assets
+                        case ExportFilter.Selected:
                             toExportAssets = GetSelectedAssets();
                             break;
-                        case 3: //Filtered Assets
+                        case ExportFilter.Filtered:
                             toExportAssets = visibleAssets;
                             break;
                     }
                     Studio.ExportAssets(saveFolderDialog.Folder, toExportAssets, exportType);
+                }
+            }
+            else
+            {
+                StatusStripUpdate("No exportable assets loaded");
+            }
+        }
+
+        private void ExportAssetsList(ExportFilter type)
+        {
+            // XXX: Only exporting as XML for now, but would JSON(/CSV/other) be useful too?
+
+            if (exportableAssets.Count > 0)
+            {
+                var saveFolderDialog = new OpenFolderDialog();
+                if (saveFolderDialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    timer.Stop();
+
+                    List<AssetItem> toExportAssets = null;
+                    switch (type)
+                    {
+                        case ExportFilter.All:
+                            toExportAssets = exportableAssets;
+                            break;
+                        case ExportFilter.Selected:
+                            toExportAssets = GetSelectedAssets();
+                            break;
+                        case ExportFilter.Filtered:
+                            toExportAssets = visibleAssets;
+                            break;
+                    }
+                    Studio.ExportAssetsList(saveFolderDialog.Folder, toExportAssets, ExportListType.XML);
                 }
             }
             else


### PR DESCRIPTION
Hi!

I've been using AssetStudio, and it's been great. But because assets are exported with filenames as the asset name, it was impossible to follow references via "path ID" from other assets.

So, I've added an XML exporter to the Export menu ("All", "Selected", and "Filtered"), which will dump a list that looks like...

```xml
<?xml version="1.0" encoding="utf-8"?>
<Assets filename="D:\path\to\assets.xml" createdAt="2021-03-21T18:16:49">
  <Asset>
    <Name>PermanentManager</Name>
    <Container></Container>
    <Type id="114">MonoBehaviour</Type>
    <PathID>5593</PathID>
    <Source>D:\path\to\asset\level0</Source>
    <Size>32</Size>
  </Asset>
  <Asset>
    <Name>TextTranslation</Name>
    <Container></Container>
    <Type id="114">MonoBehaviour</Type>
    <PathID>5594</PathID>
    <Source>D:\path\to\asset\level0</Source>
    <Size>536</Size>
  </Asset>
  <Asset>
    <Name>EventSystem</Name>
    <Container></Container>
    <Type id="114">MonoBehaviour</Type>
    <PathID>5595</PathID>
    <Source>D:\path\to\asset\level0</Source>
    <Size>52</Size>
  </Asset>

  <!-- ...etc -->
</Assets>
```

The only issue I really see right now, is that It doesn't match duplicate names (that have files like `SomeName #1234.ext` when exported), so if a project has a lot of duplicates it's still a little hard to follow. But, it's been helpful for me, so might be useful for others too :)

In future, I'd love to have the metadata directly in the preview(+export) and/or making the `m_pathID` entries clickable that jump straight to the asset.

I'd add CSV/JSON but didn't want to add dependencies, but happy to do so if that's helpful also.

Addresses #517 (somewhat).