### PR TITLE
Fix AssemblyLoading bug

### DIFF
--- a/AssetStudioUtility/AssemblyLoader.cs
+++ b/AssetStudioUtility/AssemblyLoader.cs
@@ -15,18 +15,18 @@ namespace AssetStudio
             var resolver = new MyAssemblyResolver();
             var readerParameters = new ReaderParameters();
             readerParameters.AssemblyResolver = resolver;
-            try
+            foreach (var file in files)
             {
-                foreach (var file in files)
+                try
                 {
                     var assembly = AssemblyDefinition.ReadAssembly(file, readerParameters);
                     resolver.Register(assembly);
                     moduleDic.Add(assembly.MainModule.Name, assembly.MainModule);
                 }
-            }
-            catch
-            {
-                // ignored
+                catch
+                {
+                    // ignored
+                }
             }
             Loaded = true;
         }


### PR DESCRIPTION
If the AssemblyLoader attempted to load a non-csil dll
while iterating through the file list, it would catch the exception
OUTSIDE the loop, and wouldn't load the rest.
This fix makes it catch inside the loop so it will continue iterating.