### PR TITLE
Texture2DDecoderNative - GCC - Add missing header for `memset`

### DIFF
--- a/Texture2DDecoderNative/crunch/crn_decomp.h
+++ b/Texture2DDecoderNative/crunch/crn_decomp.h
@@ -319,6 +319,7 @@ namespace crnd
 #include <memory.h>
 #else
 #include <malloc.h>
+#include <string.h>
 #endif
 #include <stdarg.h>
 #include <new> // needed for placement new, _msize, _expand

--- a/Texture2DDecoderNative/unitycrunch/crn_decomp.h
+++ b/Texture2DDecoderNative/unitycrunch/crn_decomp.h
@@ -21,6 +21,7 @@
 #include <memory.h>
 #else
 #include <malloc.h>
+#include <string.h>
 #endif
 #include <stdarg.h>
 #include <new>  // needed for placement new, _msize, _expand


### PR DESCRIPTION
`Texture2DDecoderNative` fails to build with GNU toolchain due to `memset` undefined.
This pull request adds `string.h` to `crn_depcomp.h` so the compilation can success.

**Note:**

This is the minimum effort to make it compile **with gcc** when **NDEBUG is set** (i.e. in release mode). \
However, compilation still fails when NDEBUG is not set or clang is used due to pointer cast problem, for example:
```
crunch/crn_decomp.h: In function ‘void* crnd::crnd_malloc(size_t, size_t*)’:
crunch/crn_decomp.h:2534:20: error: cast from ‘crnd::uint8*’ {aka ‘unsigned char*’} to ‘crnd::uint32’ {aka ‘unsigned int’} loses precision [-fpermissive]
```