### PR TITLE
use FullPath instead of FileName for easier identification of broken file

### DIFF
--- a/AssetStudio/AssetsManager.cs
+++ b/AssetStudio/AssetsManager.cs
@@ -91,7 +91,7 @@ namespace AssetStudio
         {
             if (!assetsFileListHash.Contains(reader.FileName))
             {
-                Logger.Info($"Loading {reader.FileName}");
+                Logger.Info($"Loading {reader.FullPath}");
                 try
                 {
                     var assetsFile = new SerializedFile(reader, this);
@@ -125,12 +125,13 @@ namespace AssetStudio
                 }
                 catch (Exception e)
                 {
-                    Logger.Error($"Error while reading assets file {reader.FileName}", e);
+                    Logger.Error($"Error while reading assets file {reader.FullPath}", e);
                     reader.Dispose();
                 }
             }
             else
             {
+                Logger.Info($"Skipping {reader.FullPath}");
                 reader.Dispose();
             }
         }
@@ -157,11 +158,13 @@ namespace AssetStudio
                     resourceFileReaders.Add(reader.FileName, reader);
                 }
             }
+            else
+                Logger.Info($"Skipping {originalPath} ({reader.FileName})");
         }
 
         private void LoadBundleFile(FileReader reader, string originalPath = null)
         {
-            Logger.Info("Loading " + reader.FileName);
+            Logger.Info("Loading " + reader.FullPath);
             try
             {
                 var bundleFile = new BundleFile(reader);
@@ -181,7 +184,7 @@ namespace AssetStudio
             }
             catch (Exception e)
             {
-                var str = $"Error while reading bundle file {reader.FileName}";
+                var str = $"Error while reading bundle file {reader.FullPath}";
                 if (originalPath != null)
                 {
                     str += $" from {Path.GetFileName(originalPath)}";
@@ -196,7 +199,7 @@ namespace AssetStudio
 
         private void LoadWebFile(FileReader reader)
         {
-            Logger.Info("Loading " + reader.FileName);
+            Logger.Info("Loading " + reader.FullPath);
             try
             {
                 var webFile = new WebFile(reader);
@@ -223,7 +226,7 @@ namespace AssetStudio
             }
             catch (Exception e)
             {
-                Logger.Error($"Error while reading web file {reader.FileName}", e);
+                Logger.Error($"Error while reading web file {reader.FullPath}", e);
             }
             finally
             {
@@ -373,6 +376,7 @@ namespace AssetStudio
                         var sb = new StringBuilder();
                         sb.AppendLine("Unable to load object")
                             .AppendLine($"Assets {assetsFile.fileName}")
+                            .AppendLine($"Path {assetsFile.originalPath}")
                             .AppendLine($"Type {objectReader.type}")
                             .AppendLine($"PathID {objectInfo.m_PathID}")
                             .Append(e);

--- a/AssetStudio/AssetsManager.cs
+++ b/AssetStudio/AssetsManager.cs
@@ -154,7 +154,7 @@ namespace AssetStudio
                 }
                 catch (Exception e)
                 {
-                    Logger.Error($"Error while reading assets file {reader.FileName} from {Path.GetFileName(originalPath)}", e);
+                    Logger.Error($"Error while reading assets file {reader.FullPath} from {Path.GetFileName(originalPath)}", e);
                     resourceFileReaders.Add(reader.FileName, reader);
                 }
             }


### PR DESCRIPTION
use FullPath instead of FileName for easier identification of broken file