### PR TITLE
Zip (including APK) Loading

### DIFF
--- a/AssetStudio/AssetStudio.csproj
+++ b/AssetStudio/AssetStudio.csproj
@@ -17,4 +17,5 @@
     <PackageReference Include="System.IO.Compression" Version="4.0.0" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
   </ItemGroup>
+
 </Project>

--- a/AssetStudio/AssetStudio.csproj
+++ b/AssetStudio/AssetStudio.csproj
@@ -14,8 +14,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.IO.Compression" />
+    <PackageReference Include="System.IO.Compression" Version="4.0.0" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
   </ItemGroup>
-  
 </Project>

--- a/AssetStudio/AssetStudio.csproj
+++ b/AssetStudio/AssetStudio.csproj
@@ -14,7 +14,8 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.IO.Compression" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
   </ItemGroup>
-
+  
 </Project>

--- a/AssetStudio/AssetsManager.cs
+++ b/AssetStudio/AssetsManager.cs
@@ -244,16 +244,27 @@ namespace AssetStudio
                 {
                     foreach (ZipArchiveEntry entry in archive.Entries)
                     {
-                        string dummyPath = Path.Combine(Path.GetDirectoryName(reader.FullPath), reader.FileName, entry.FullName);
-                        // create a new stream
-                        // - to store the deflated stream in
-                        // - to keep the data for later extraction
-                        Stream streamReader = new MemoryStream();
-                        entry.Open().CopyTo(streamReader);
-                        streamReader.Position = 0;
+                        try
+                        {
+                            string dummyPath = Path.Combine(Path.GetDirectoryName(reader.FullPath), reader.FileName, entry.FullName);
+                            // create a new stream
+                            // - to store the deflated stream in
+                            // - to keep the data for later extraction
+                            Stream streamReader = new MemoryStream();
+                            entry.Open().CopyTo(streamReader);
+                            streamReader.Position = 0;
 
-                        FileReader entryReader = new FileReader(dummyPath, streamReader);
-                        LoadFile(entryReader);
+                            FileReader entryReader = new FileReader(dummyPath, streamReader);
+                            LoadFile(entryReader);
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.Error($"Error while reading zip entry {entry.FullName}", e);
+                        }
+                        finally
+                        {
+                            reader.Dispose();
+                        }
                     }
                 }
             }

--- a/AssetStudio/AssetsManager.cs
+++ b/AssetStudio/AssetsManager.cs
@@ -253,21 +253,7 @@ namespace AssetStudio
                         streamReader.Position = 0;
 
                         FileReader entryReader = new FileReader(dummyPath, streamReader);
-                        switch (entryReader.FileType)
-                        {
-                            case FileType.AssetsFile:
-                                LoadAssetsFromMemory(entryReader, reader.FullPath);
-                                break;
-                            case FileType.BundleFile:
-                                LoadBundleFile(entryReader, reader.FullPath);
-                                break;
-                            case FileType.WebFile:
-                                LoadWebFile(entryReader);
-                                break;
-                            case FileType.ResourceFile:
-                                resourceFileReaders[entry.Name] = entryReader; //TODO
-                                break;
-                        }
+                        LoadFile(entryReader);
                     }
                 }
             }

--- a/AssetStudio/AssetsManager.cs
+++ b/AssetStudio/AssetsManager.cs
@@ -251,7 +251,10 @@ namespace AssetStudio
                             // - to store the deflated stream in
                             // - to keep the data for later extraction
                             Stream streamReader = new MemoryStream();
-                            entry.Open().CopyTo(streamReader);
+                            using (Stream entryStream = entry.Open())
+                            {
+                                entryStream.CopyTo(streamReader);
+                            }
                             streamReader.Position = 0;
 
                             FileReader entryReader = new FileReader(dummyPath, streamReader);
@@ -260,10 +263,6 @@ namespace AssetStudio
                         catch (Exception e)
                         {
                             Logger.Error($"Error while reading zip entry {entry.FullName}", e);
-                        }
-                        finally
-                        {
-                            reader.Dispose();
                         }
                     }
                 }

--- a/AssetStudio/FileReader.cs
+++ b/AssetStudio/FileReader.cs
@@ -11,6 +11,9 @@ namespace AssetStudio
 
         private static readonly byte[] gzipMagic = { 0x1f, 0x8b };
         private static readonly byte[] brotliMagic = { 0x62, 0x72, 0x6F, 0x74, 0x6C, 0x69 };
+        private static readonly byte[] zipMagic = { 0x50, 0x4B, 0x03, 0x04 };
+        private static readonly byte[] zipSpannedMagic = { 0x50, 0x4B, 0x07, 0x08 };
+
 
         public FileReader(string path) : this(path, File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) { }
 
@@ -36,7 +39,7 @@ namespace AssetStudio
                     return FileType.WebFile;
                 default:
                     {
-                        var magic = ReadBytes(2);
+                        byte[] magic = ReadBytes(2);
                         Position = 0;
                         if (gzipMagic.SequenceEqual(magic))
                         {
@@ -53,10 +56,11 @@ namespace AssetStudio
                         {
                             return FileType.AssetsFile;
                         }
-                        else
-                        {
-                            return FileType.ResourceFile;
-                        }
+                        magic = ReadBytes(4);
+                        Position = 0;
+                        if (zipMagic.SequenceEqual(magic) || zipSpannedMagic.SequenceEqual(magic))
+                            return FileType.ZipFile;
+                        return FileType.ResourceFile;
                     }
             }
         }

--- a/AssetStudio/FileReader.cs
+++ b/AssetStudio/FileReader.cs
@@ -14,7 +14,6 @@ namespace AssetStudio
         private static readonly byte[] zipMagic = { 0x50, 0x4B, 0x03, 0x04 };
         private static readonly byte[] zipSpannedMagic = { 0x50, 0x4B, 0x07, 0x08 };
 
-
         public FileReader(string path) : this(path, File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) { }
 
         public FileReader(string path, Stream stream) : base(stream, EndianType.BigEndian)

--- a/AssetStudio/FileType.cs
+++ b/AssetStudio/FileType.cs
@@ -13,6 +13,7 @@ namespace AssetStudio
         WebFile,
         ResourceFile,
         GZipFile,
-        BrotliFile
+        BrotliFile,
+        ZipFile
     }
 }


### PR DESCRIPTION
This PR makes it possible to load most zip files, including apk and apkx files, directly with AssetStudio.

Zips are identified via the magic number of the .zip format that can be found at [Wikipedia: ZIP (file format)](https://en.wikipedia.org/wiki/ZIP_(file_format)).
Once a zip is identified, the code tries to load all of its entries via the already given LoadFile function.
This in turn allows recursive parsing of zips within zips, which allows directly parsing apkx files as well.

