### PR TITLE
fix for Unity2021.3.2f1

### DIFF
--- a/AssetStudio/BundleFile.cs
+++ b/AssetStudio/BundleFile.cs
@@ -300,6 +300,7 @@ namespace AssetStudio
                     case 2: //LZ4
                     case 3: //LZ4HC
                         {
+                            JumpToNotZero(reader.BaseStream);
                             var compressedSize = (int)blockInfo.compressedSize;
                             var compressedBytes = BigArrayPool<byte>.Shared.Rent(compressedSize);
                             reader.Read(compressedBytes, 0, compressedSize);
@@ -318,6 +319,22 @@ namespace AssetStudio
                 }
             }
             blocksStream.Position = 0;
+        }
+
+        public static int JumpToNotZero(Stream stream)
+        {
+            var offset = 0;
+            for (int i = 0; i < stream.Length; i++)
+            {
+                var currentByte = stream.ReadByte();
+                if (currentByte != 0)
+                {
+                    offset = i;
+                    stream.Position -= 1;
+                    break;
+                }
+            }
+            return offset;
         }
     }
 }

--- a/AssetStudio/SevenZipHelper.cs
+++ b/AssetStudio/SevenZipHelper.cs
@@ -38,12 +38,25 @@ namespace AssetStudio
         {
             var basePosition = compressedStream.Position;
             var decoder = new Decoder();
+
+            var offset = 0;
+            for (int i = 0; i < compressedStream.Length; i++)
+            {
+                var currentByte = compressedStream.ReadByte();
+                if (currentByte != 0)
+                {
+                    offset = i;
+                    compressedStream.Position -= 1;
+                    break;
+                }
+            }
+
             var properties = new byte[5];
             if (compressedStream.Read(properties, 0, 5) != 5)
                 throw new Exception("input .lzma is too short");
             decoder.SetDecoderProperties(properties);
             decoder.Code(compressedStream, decompressedStream, compressedSize - 5, decompressedSize, null);
-            compressedStream.Position = basePosition + compressedSize;
+            compressedStream.Position = basePosition + compressedSize + offset;
         }
     }
 }

--- a/AssetStudio/SevenZipHelper.cs
+++ b/AssetStudio/SevenZipHelper.cs
@@ -39,17 +39,7 @@ namespace AssetStudio
             var basePosition = compressedStream.Position;
             var decoder = new Decoder();
 
-            var offset = 0;
-            for (int i = 0; i < compressedStream.Length; i++)
-            {
-                var currentByte = compressedStream.ReadByte();
-                if (currentByte != 0)
-                {
-                    offset = i;
-                    compressedStream.Position -= 1;
-                    break;
-                }
-            }
+            var offset = BundleFile.JumpToNotZero(compressedStream);
 
             var properties = new byte[5];
             if (compressedStream.Read(properties, 0, 5) != 5)


### PR DESCRIPTION
# 1 AssetStudio v0.16.40 can't extract Unity2021.3.2f1
AssetStudio v0.16.40 can't extract  any Unity2021.3.2f1(also Unity2020.3.34f1)'s assetbundles with an error(SevenZip.DataErrorException) as shown below.

## 1.1 AssetStudio v0.16.40 can't work with Unity2021.3.2f1/Unity2020.3.34f1

Compress with LZMA:
![](https://cdn.jsdelivr.net/gh/zhangjiequan/ImageHosting/img/20220516083558.png)
Compress with LZ4:
![](https://cdn.jsdelivr.net/gh/zhangjiequan/ImageHosting/img/20220519190514.png)

This AB above is a Unity2021.3.2f1's assetbundle, the original asset is a texutre.

assetbundles: https://github.com/zhangjiequan/ImageHosting/blob/master/ForShare/AB-Win-Unity2021.3.2f1/r256256

texutre: https://github.com/zhangjiequan/ImageHosting/blob/master/ForShare/Assets-fix-for-Unity2021.3.2f1/R256256.png  texutre's meta: https://github.com/zhangjiequan/ImageHosting/blob/master/ForShare/Assets-fix-for-Unity2021.3.2f1/R256256.png.meta

## 1.2 AssetStudio v0.16.40 can work with Unity2021.3.1f1/Unity2020.3.33f1
And  I buid the same asset with Unity2021.3.1f1, I get assetbundles.  AssetStudio v0.16.40 can extract it.

assetbundles: https://github.com/zhangjiequan/ImageHosting/blob/master/ForShare/AB-Win-Unity2021.3.1f1/r256256

# 2 Related to “padding is added after blocks info”？
I guess it's probably related to this:

https://unity3d.com/unity/whats-new/2021.3.2
> Asset Bundles: Ensure that padding is added after blocks info so that Switch patching works appropriately. This fix implies that loading newly generated AssetBundles will require using this new Unity editor/runtime combination.

https://issuetracker.unity3d.com/issues/files-within-assetbundles-do-not-start-on-aligned-boundaries-breaking-patching-on-nintendo-switch
> files within assetbundles do not start on aligned boundaries, breaking patching on nintendo switch.

As we see, Unity fix this issues on Unity2021.3.2f1/Unity2020.3.34f1. AssetStudio v0.16.40 can work with Unity2021.3.1f1/Unity2020.3.33f1, and AssetStudio v0.16.40 can't work with Unity2021.3.2f1/Unity2020.3.34f1.
So I guess it's probably related to this.

# 3 My work
So, here, I try to skip this "padding"  when extracting the assetbundles, and it works.
Now AssetStudio can extract Unity2021.3.2f1(also Unity2020.3.34f1)'s assetbundles(LZ4 & LZMA).

Unity2021.3.2f1:
![](https://cdn.jsdelivr.net/gh/zhangjiequan/ImageHosting/img/20220519225441.png)

Unity2020.3.34f1:
![](https://cdn.jsdelivr.net/gh/zhangjiequan/ImageHosting/img/20220519225351.png)

I'm not quite sure if this is going to cause other problems. I look forward to your suggestions.

---

作者Perfare哥也是中国人，所以来个中文版

# 1 AssetStudio v0.16.40不能提取Unity2021.3.2f1打出来的AB
对任意的Unity2021.3.2f1打出来的AB包，AssetStudio v0.16.40都不能提取，Unity2020.3.34f1的也是。提取的时候会报一个SevenZip.DataErrorException的错，如下图所示。

## 1.1 AssetStudio v0.16.40不能提取Unity2021.3.2f1、Unity2020.3.34f1打出来的AB

用LZMA格式压缩:
![](https://cdn.jsdelivr.net/gh/zhangjiequan/ImageHosting/img/20220516083558.png)
用LZ4格式压缩:
![](https://cdn.jsdelivr.net/gh/zhangjiequan/ImageHosting/img/20220519190514.png)

上图中，这个AB是Unity2021.3.2f1打出来的，AB中包含了一张贴图。

AB下载地址：https://github.com/zhangjiequan/ImageHosting/blob/master/ForShare/AB-Win-Unity2021.3.2f1/r256256

贴图下载地址：https://github.com/zhangjiequan/ImageHosting/blob/master/ForShare/Assets-fix-for-Unity2021.3.2f1/R256256.png 
贴图的meta的下载地址：: https://github.com/zhangjiequan/ImageHosting/blob/master/ForShare/Assets-fix-for-Unity2021.3.2f1/R256256.png.meta

我也试过用Unity2020.3.34f1打AB，AssetStudio也不能提取。

大家可以下载这些资源，来复现问题。

## 1.2 AssetStudio v0.16.40可以提取Unity2021.3.1f1、Unity2020.3.33f1打出来的AB

我也尝试过使用Unity2021.3.1f1，对上面这张贴图及相同的meta，进行了打AB包（其它设置完全一样，唯一不同的是Unity版本），AssetStudio v0.16.40可以提取Unity2021.3.1f1打出来的AB包（Unity2020.3.33f1也是可以的）。

AB下载地址: https://github.com/zhangjiequan/ImageHosting/blob/master/ForShare/AB-Win-Unity2021.3.1f1/r256256

# 2 是否和“padding is added after blocks info”有关？

我猜，AssetStudio在新版Unity不能工作，很可能和Unity最近修改的这个特性有关：

https://unity3d.com/unity/whats-new/2021.3.2
> Asset Bundles: Ensure that padding is added after blocks info so that Switch patching works appropriately. This fix implies that loading newly generated AssetBundles will require using this new Unity editor/runtime combination.

https://issuetracker.unity3d.com/issues/files-within-assetbundles-do-not-start-on-aligned-boundaries-breaking-patching-on-nintendo-switch
> files within assetbundles do not start on aligned boundaries, breaking patching on nintendo switch.

注意到，Unity在Unity2021.3.2f1、Unity2020.3.34f1等版本做了上述修改。而AssetStudio v0.16.40正好是在Unity2021.3.2f1、Unity2020.3.34f1就不能正常工作，在Unity2021.3.2f1、Unity2020.3.34f1之前的版本能正常工作。
所以，我猜和这个有关。

# 3 我做的修改
因为Unity在新版本对AB加了一些padding，所以我尝试在提取AB时跳过这些padding（其实我也不确认我跳过的这些为0的byte是不是就是padding），然后AssetStudio就能正常提取新版Unity（我在Unity2021.3.2f1/Unity2020.3.34f1进行了验证）打出的AB了。经测试，能支持LZ4和LZMA。

Unity2021.3.2f1:
![](https://cdn.jsdelivr.net/gh/zhangjiequan/ImageHosting/img/20220519225441.png)

Unity2020.3.34f1:
![](https://cdn.jsdelivr.net/gh/zhangjiequan/ImageHosting/img/20220519225351.png)

我不是很确定这个修改是否会引入其它问题，请大佬们指点指点。
（可以看到，我的代码是通过逐个byte来判断是否非0的，bad smells in code。应该有更优雅的做法？）
（另外，好奇Perfare哥是如何能知道Unity对AB的压缩&序列化算法的？是源码用户？能帮忙看看新版Unity对AB具体做了什么修改，然后看看怎么更好地对应去修改AssetStudio?）